### PR TITLE
Add admin interfaces for users, roles and permissions

### DIFF
--- a/app/admin/role_permissions.php
+++ b/app/admin/role_permissions.php
@@ -1,4 +1,58 @@
-
 <?php
 require_once __DIR__.'/../core/bootstrap.php'; requirePerm($perms,'user.manage');
-echo "<h1>Role Permissions Placeholder</h1>";
+
+if ($_SERVER['REQUEST_METHOD']==='POST') {
+  checkCsrfOrFail();
+  $roleId=(int)($_POST['role_id'] ?? 0);
+  $permIds=$_POST['permissions'] ?? [];
+  $st=$conn->prepare("DELETE FROM role_permission WHERE role_id=?");
+  $st->bind_param('i',$roleId); $st->execute(); $st->close();
+  if (is_array($permIds)) {
+    foreach($permIds as $pid){
+      $pid=(int)$pid;
+      $st=$conn->prepare("INSERT INTO role_permission (role_id,permission_id) VALUES (?,?)");
+      $st->bind_param('ii',$roleId,$pid); $st->execute(); $st->close();
+    }
+  }
+  header('Location: role_permissions.php?role='.$roleId); exit;
+}
+
+$roles=$conn->query("SELECT id,name FROM role ORDER BY name")->fetch_all(MYSQLI_ASSOC);
+$permsAll=$conn->query("SELECT id,code FROM permission ORDER BY code")->fetch_all(MYSQLI_ASSOC);
+$table=$conn->query("SELECT r.name,GROUP_CONCAT(p.code ORDER BY p.code SEPARATOR ', ') perms FROM role r LEFT JOIN role_permission rp ON rp.role_id=r.id LEFT JOIN permission p ON p.id=rp.permission_id GROUP BY r.id ORDER BY r.id")->fetch_all(MYSQLI_ASSOC);
+$selectedRole=isset($_GET['role'])?(int)$_GET['role']:(($roles[0]['id']??0));
+$selectedPerms=[];
+if($selectedRole){
+  $st=$conn->prepare("SELECT permission_id FROM role_permission WHERE role_id=?");
+  $st->bind_param('i',$selectedRole); $st->execute();
+  $selectedPerms=array_column($st->get_result()->fetch_all(MYSQLI_ASSOC),'permission_id');
+  $st->close();
+}
+?>
+<!doctype html><html><body>
+<h1>Role Permissions</h1>
+<table border="1">
+<tr><th>Role</th><th>Permissions</th></tr>
+<?php foreach($table as $row): ?>
+<tr>
+  <td><?=h($row['name'])?></td>
+  <td><?=h($row['perms'])?></td>
+</tr>
+<?php endforeach; ?>
+</table>
+<hr>
+<form method="post">
+<input type="hidden" name="csrf" value="<?=h(csrfToken())?>">
+<label>Role <select name="role_id">
+<?php foreach($roles as $r): $sel=$r['id']==$selectedRole?' selected':''; ?>
+<option value="<?=$r['id']?>"<?=$sel?>><?=h($r['name'])?></option>
+<?php endforeach; ?>
+</select></label><br>
+<label>Permissions <select name="permissions[]" multiple size="5">
+<?php foreach($permsAll as $p): $sel=in_array($p['id'],$selectedPerms)?' selected':''; ?>
+<option value="<?=$p['id']?>"<?=$sel?>><?=h($p['code'])?></option>
+<?php endforeach; ?>
+</select></label><br>
+<button type="submit">Save</button>
+</form>
+</body></html>

--- a/app/admin/roles.php
+++ b/app/admin/roles.php
@@ -1,4 +1,48 @@
-
 <?php
 require_once __DIR__.'/../core/bootstrap.php'; requirePerm($perms,'user.manage');
-echo "<h1>Roles Placeholder</h1>";
+
+if ($_SERVER['REQUEST_METHOD']==='POST') {
+  checkCsrfOrFail();
+  $name=trim($_POST['name']??'');
+  if ($name===''){ http_response_code(422); exit('missing'); }
+  if (($_POST['id']??'')!=='') {
+      $id=(int)$_POST['id'];
+      $st=$conn->prepare("UPDATE role SET name=? WHERE id=?");
+      $st->bind_param('si',$name,$id); $st->execute(); $st->close();
+  } else {
+      $st=$conn->prepare("INSERT INTO role (name) VALUES (?)");
+      $st->bind_param('s',$name); $st->execute(); $st->close();
+  }
+  header('Location: roles.php'); exit;
+}
+
+$roles = $conn->query("SELECT id,name FROM role ORDER BY id")->fetch_all(MYSQLI_ASSOC);
+$edit = null;
+if (isset($_GET['edit'])) {
+    $id=(int)$_GET['edit'];
+    $st=$conn->prepare("SELECT id,name FROM role WHERE id=?");
+    $st->bind_param('i',$id); $st->execute();
+    $edit=$st->get_result()->fetch_assoc();
+    $st->close();
+}
+?>
+<!doctype html><html><body>
+<h1>Roles</h1>
+<table border="1">
+<tr><th>ID</th><th>Name</th><th>Actions</th></tr>
+<?php foreach($roles as $r): ?>
+<tr>
+  <td><?=h($r['id'])?></td>
+  <td><?=h($r['name'])?></td>
+  <td><a href="?edit=<?=$r['id']?>">Edit</a></td>
+</tr>
+<?php endforeach; ?>
+</table>
+<hr>
+<form method="post">
+<input type="hidden" name="csrf" value="<?=h(csrfToken())?>">
+<input type="hidden" name="id" value="<?=h($edit['id'] ?? '')?>">
+<label>Name <input name="name" value="<?=h($edit['name'] ?? '')?>"></label>
+<button type="submit"><?= $edit ? 'Update' : 'Create' ?></button>
+</form>
+</body></html>

--- a/app/admin/users.php
+++ b/app/admin/users.php
@@ -1,4 +1,81 @@
-
 <?php
 require_once __DIR__.'/../core/bootstrap.php'; requirePerm($perms,'user.manage');
-echo "<h1>Users Placeholder</h1>";
+
+if ($_SERVER['REQUEST_METHOD']==='POST') {
+  checkCsrfOrFail();
+  $username=trim($_POST['username']??'');
+  $email=trim($_POST['email']??'');
+  $roles=$_POST['roles']??[];
+  $password=$_POST['password']??'';
+  if($username===''||$email===''){ http_response_code(422); exit('missing'); }
+  if (($_POST['id']??'')!=='') {
+      $id=(int)$_POST['id'];
+      $st=$conn->prepare("UPDATE user SET username=?, email=? WHERE id=?");
+      $st->bind_param('ssi',$username,$email,$id); $st->execute(); $st->close();
+      if($password!==''){
+          $hash=password_hash($password,PASSWORD_DEFAULT);
+          $st=$conn->prepare("UPDATE user SET password_hash=? WHERE id=?");
+          $st->bind_param('si',$hash,$id); $st->execute(); $st->close();
+      }
+  } else {
+      if($password===''){ http_response_code(422); exit('missing'); }
+      $hash=password_hash($password,PASSWORD_DEFAULT);
+      $verified=date('Y-m-d H:i:s');
+      $st=$conn->prepare("INSERT INTO user (username,password_hash,email,email_verified_at) VALUES (?,?,?,?)");
+      $st->bind_param('ssss',$username,$hash,$email,$verified); $st->execute(); $st->close();
+      $id=$conn->insert_id;
+  }
+  $st=$conn->prepare("DELETE FROM user_role WHERE user_id=?"); $st->bind_param('i',$id); $st->execute(); $st->close();
+  if (is_array($roles)) {
+    foreach($roles as $rid){
+        $rid=(int)$rid;
+        $st=$conn->prepare("INSERT INTO user_role (user_id,role_id) VALUES (?,?)");
+        $st->bind_param('ii',$id,$rid); $st->execute(); $st->close();
+    }
+  }
+  header('Location: users.php'); exit;
+}
+
+$users=$conn->query("SELECT u.id,u.username,u.email,GROUP_CONCAT(r.name ORDER BY r.name SEPARATOR ', ') roles FROM user u LEFT JOIN user_role ur ON ur.user_id=u.id LEFT JOIN role r ON r.id=ur.role_id GROUP BY u.id ORDER BY u.id")->fetch_all(MYSQLI_ASSOC);
+$allRoles=$conn->query("SELECT id,name FROM role ORDER BY name")->fetch_all(MYSQLI_ASSOC);
+$edit=null; $editRoles=[];
+if(isset($_GET['edit'])) {
+    $id=(int)$_GET['edit'];
+    $st=$conn->prepare("SELECT id,username,email FROM user WHERE id=?");
+    $st->bind_param('i',$id); $st->execute();
+    $edit=$st->get_result()->fetch_assoc(); $st->close();
+    $st=$conn->prepare("SELECT role_id FROM user_role WHERE user_id=?");
+    $st->bind_param('i',$id); $st->execute();
+    $editRoles=array_column($st->get_result()->fetch_all(MYSQLI_ASSOC),'role_id');
+    $st->close();
+}
+?>
+<!doctype html><html><body>
+<h1>Users</h1>
+<table border="1">
+<tr><th>ID</th><th>Username</th><th>Email</th><th>Roles</th><th>Actions</th></tr>
+<?php foreach($users as $u): ?>
+<tr>
+  <td><?=h($u['id'])?></td>
+  <td><?=h($u['username'])?></td>
+  <td><?=h($u['email'])?></td>
+  <td><?=h($u['roles'])?></td>
+  <td><a href="?edit=<?=$u['id']?>">Edit</a></td>
+</tr>
+<?php endforeach; ?>
+</table>
+<hr>
+<form method="post">
+<input type="hidden" name="csrf" value="<?=h(csrfToken())?>">
+<input type="hidden" name="id" value="<?=h($edit['id'] ?? '')?>">
+<label>Username <input name="username" value="<?=h($edit['username'] ?? '')?>"></label><br>
+<label>Email <input type="email" name="email" value="<?=h($edit['email'] ?? '')?>"></label><br>
+<label>Password <input type="password" name="password"></label><br>
+<label>Roles <select name="roles[]" multiple size="5">
+<?php foreach($allRoles as $r): $sel=in_array($r['id'],$editRoles) ? ' selected' : ''; ?>
+<option value="<?=$r['id']?>"<?=$sel?>><?=h($r['name'])?></option>
+<?php endforeach; ?>
+</select></label><br>
+<button type="submit"><?= $edit ? 'Update' : 'Create' ?></button>
+</form>
+</body></html>


### PR DESCRIPTION
## Summary
- Implement user management with role assignment via multi-select controls
- Add role listing and creation/editing forms
- Enable role-permission editing with multi-select permission picker

## Testing
- `php -l app/admin/roles.php`
- `php -l app/admin/users.php`
- `php -l app/admin/role_permissions.php`


------
https://chatgpt.com/codex/tasks/task_e_68c01e49b75483318af3b23646c0a336