### PR TITLE
Add admin management for users, roles and permissions

### DIFF
--- a/app/admin/role_permissions.php
+++ b/app/admin/role_permissions.php
@@ -1,7 +1,86 @@
-
 <?php
-require_once __DIR__.'/../core/bootstrap.php'; requirePerm($perms,'user.manage');
-$title='Role Permissions'; require __DIR__.'/../core/header.php';
+require_once __DIR__.'/../core/bootstrap.php';
+requirePerm($perms,'user.manage');
+
+if($_SERVER['REQUEST_METHOD']==='POST'){
+    checkCsrfOrFail();
+    $roleId = (int)($_POST['role_id'] ?? 0);
+    $permsSel = $_POST['permissions'] ?? [];
+
+    $del = $conn->prepare("DELETE FROM role_permission WHERE role_id=?");
+    $del->bind_param('i', $roleId);
+    $del->execute();
+    $del->close();
+
+    if(!empty($permsSel)){
+        $ins = $conn->prepare("INSERT INTO role_permission (role_id,permission_id) VALUES (?,?)");
+        foreach($permsSel as $pid){
+            $pid = (int)$pid;
+            $ins->bind_param('ii', $roleId, $pid);
+            $ins->execute();
+        }
+        $ins->close();
+    }
+
+    header('Location: role_permissions.php?role_id='.$roleId);
+    exit;
+}
+
+$rolePerms = $conn->query(
+    "SELECT r.id,r.name, GROUP_CONCAT(p.code SEPARATOR ', ') perms " .
+    "FROM role r " .
+    "LEFT JOIN role_permission rp ON rp.role_id=r.id " .
+    "LEFT JOIN permission p ON p.id=rp.permission_id " .
+    "GROUP BY r.id ORDER BY r.id"
+)->fetch_all(MYSQLI_ASSOC);
+
+$roleId = (int)($_GET['role_id'] ?? 0);
+$roles = $conn->query("SELECT id,name FROM role ORDER BY name")->fetch_all(MYSQLI_ASSOC);
+$permissions = $conn->query("SELECT id,code FROM permission ORDER BY code")->fetch_all(MYSQLI_ASSOC);
+$selected = [];
+if($roleId){
+    $st = $conn->prepare("SELECT permission_id FROM role_permission WHERE role_id=?");
+    $st->bind_param('i', $roleId);
+    $st->execute();
+    $selected = array_column($st->get_result()->fetch_all(MYSQLI_ASSOC), 'permission_id');
+    $st->close();
+}
+
+$title='Role Permissions';
+require __DIR__.'/../core/header.php';
 ?>
-<h1>Role Permissions Placeholder</h1>
+<h1>Role Permissions</h1>
+
+<table border="1" cellpadding="4">
+<tr><th>Role</th><th>Permissions</th><th></th></tr>
+<?php foreach($rolePerms as $rp): ?>
+<tr>
+  <td><?= h($rp['name']) ?></td>
+  <td><?= h($rp['perms']) ?></td>
+  <td><a href="?role_id=<?= (int)$rp['id'] ?>">edit</a></td>
+</tr>
+<?php endforeach; ?>
+</table>
+
+<h2>Assign Permissions</h2>
+<form method="post">
+  <input type="hidden" name="csrf" value="<?=h(csrfToken())?>">
+  <label>Role
+    <select name="role_id">
+      <?php foreach($roles as $r): ?>
+        <option value="<?=$r['id']?>" <?= $roleId===$r['id']?'selected':''?>><?=h($r['name'])?></option>
+      <?php endforeach; ?>
+    </select>
+  </label><br>
+  <label>Permissions
+    <select name="permissions[]" multiple size="5">
+      <?php foreach($permissions as $p): ?>
+        <option value="<?=$p['id']?>" <?= in_array($p['id'], $selected) ? 'selected' : '' ?>><?=h($p['code'])?></option>
+      <?php endforeach; ?>
+    </select>
+  </label><br>
+  <button type="submit">Save</button>
+</form>
+
 <?php require __DIR__.'/../core/footer.php'; ?>
+

--- a/app/admin/roles.php
+++ b/app/admin/roles.php
@@ -1,7 +1,65 @@
-
 <?php
-require_once __DIR__.'/../core/bootstrap.php'; requirePerm($perms,'user.manage');
-$title='Roles'; require __DIR__.'/../core/header.php';
+require_once __DIR__.'/../core/bootstrap.php';
+requirePerm($perms,'user.manage');
+
+if($_SERVER['REQUEST_METHOD']==='POST'){
+    checkCsrfOrFail();
+    $id = (int)($_POST['id'] ?? 0);
+    $name = trim($_POST['name'] ?? '');
+
+    if($id){
+        $st = $conn->prepare("UPDATE role SET name=? WHERE id=?");
+        $st->bind_param('si', $name, $id);
+        $st->execute();
+        $st->close();
+    } else {
+        $st = $conn->prepare("INSERT INTO role (name) VALUES (?)");
+        $st->bind_param('s', $name);
+        $st->execute();
+        $st->close();
+    }
+
+    header('Location: roles.php');
+    exit;
+}
+
+$roles = $conn->query("SELECT id,name FROM role ORDER BY id")->fetch_all(MYSQLI_ASSOC);
+
+$editId = (int)($_GET['edit'] ?? 0);
+$editRole = null;
+if($editId){
+    $st = $conn->prepare("SELECT id,name FROM role WHERE id=?");
+    $st->bind_param('i', $editId);
+    $st->execute();
+    $editRole = $st->get_result()->fetch_assoc();
+    $st->close();
+}
+
+$title='Roles';
+require __DIR__.'/../core/header.php';
 ?>
-<h1>Roles Placeholder</h1>
+<h1>Roles</h1>
+
+<table border="1" cellpadding="4">
+<tr><th>ID</th><th>Name</th><th></th></tr>
+<?php foreach($roles as $r): ?>
+<tr>
+  <td><?= (int)$r['id'] ?></td>
+  <td><?= h($r['name']) ?></td>
+  <td><a href="?edit=<?= (int)$r['id'] ?>">edit</a></td>
+</tr>
+<?php endforeach; ?>
+</table>
+
+<h2><?= $editRole ? 'Edit Role' : 'New Role' ?></h2>
+<form method="post">
+  <input type="hidden" name="csrf" value="<?=h(csrfToken())?>">
+  <?php if($editRole): ?>
+    <input type="hidden" name="id" value="<?= (int)$editRole['id'] ?>">
+  <?php endif; ?>
+  <label>Name <input name="name" value="<?= h($editRole['name'] ?? '') ?>"></label><br>
+  <button type="submit">Save</button>
+</form>
+
 <?php require __DIR__.'/../core/footer.php'; ?>
+

--- a/app/admin/users.php
+++ b/app/admin/users.php
@@ -1,7 +1,118 @@
-
 <?php
-require_once __DIR__.'/../core/bootstrap.php'; requirePerm($perms,'user.manage');
-$title='Users'; require __DIR__.'/../core/header.php';
+require_once __DIR__.'/../core/bootstrap.php';
+requirePerm($perms,'user.manage');
+
+if($_SERVER['REQUEST_METHOD']==='POST'){
+    checkCsrfOrFail();
+    $id = (int)($_POST['id'] ?? 0);
+    $username = trim($_POST['username'] ?? '');
+    $email = trim($_POST['email'] ?? '');
+    $password = $_POST['password'] ?? '';
+    $roles = $_POST['roles'] ?? [];
+
+    if($id){
+        if($password !== ''){
+            $hash = password_hash($password, PASSWORD_DEFAULT);
+            $st = $conn->prepare("UPDATE user SET username=?, email=?, password_hash=? WHERE id=?");
+            $st->bind_param('sssi', $username, $email, $hash, $id);
+        } else {
+            $st = $conn->prepare("UPDATE user SET username=?, email=? WHERE id=?");
+            $st->bind_param('ssi', $username, $email, $id);
+        }
+        $st->execute();
+        $st->close();
+    } else {
+        $hash = password_hash($password, PASSWORD_DEFAULT);
+        $st = $conn->prepare("INSERT INTO user (username,email,password_hash) VALUES (?,?,?)");
+        $st->bind_param('sss', $username, $email, $hash);
+        $st->execute();
+        $id = $st->insert_id;
+        $st->close();
+    }
+
+    $del = $conn->prepare("DELETE FROM user_role WHERE user_id=?");
+    $del->bind_param('i', $id);
+    $del->execute();
+    $del->close();
+
+    if(!empty($roles)){
+        $ins = $conn->prepare("INSERT INTO user_role (user_id,role_id) VALUES (?,?)");
+        foreach($roles as $rid){
+            $rid = (int)$rid;
+            $ins->bind_param('ii', $id, $rid);
+            $ins->execute();
+        }
+        $ins->close();
+    }
+
+    header('Location: users.php');
+    exit;
+}
+
+$users = $conn->query(
+    "SELECT u.id,u.username,u.email, GROUP_CONCAT(r.name SEPARATOR ', ') roles " .
+    "FROM user u " .
+    "LEFT JOIN user_role ur ON ur.user_id=u.id " .
+    "LEFT JOIN role r ON r.id=ur.role_id " .
+    "GROUP BY u.id ORDER BY u.id"
+)->fetch_all(MYSQLI_ASSOC);
+
+$editId = (int)($_GET['edit'] ?? 0);
+$editUser = null;
+$editRoles = [];
+if($editId){
+    $st = $conn->prepare("SELECT id,username,email FROM user WHERE id=?");
+    $st->bind_param('i', $editId);
+    $st->execute();
+    $editUser = $st->get_result()->fetch_assoc();
+    $st->close();
+    if($editUser){
+        $st = $conn->prepare("SELECT role_id FROM user_role WHERE user_id=?");
+        $st->bind_param('i', $editId);
+        $st->execute();
+        $editRoles = array_column($st->get_result()->fetch_all(MYSQLI_ASSOC), 'role_id');
+        $st->close();
+    }
+}
+
+$allRoles = $conn->query("SELECT id,name FROM role ORDER BY name")->fetch_all(MYSQLI_ASSOC);
+
+$title='Users';
+require __DIR__.'/../core/header.php';
 ?>
-<h1>Users Placeholder</h1>
+<h1>Users</h1>
+
+<table border="1" cellpadding="4">
+<tr><th>ID</th><th>Username</th><th>Email</th><th>Roles</th><th></th></tr>
+<?php foreach($users as $u): ?>
+<tr>
+  <td><?= (int)$u['id'] ?></td>
+  <td><?= h($u['username']) ?></td>
+  <td><?= h($u['email']) ?></td>
+  <td><?= h($u['roles']) ?></td>
+  <td><a href="?edit=<?= (int)$u['id'] ?>">edit</a></td>
+ </tr>
+<?php endforeach; ?>
+</table>
+
+<h2><?= $editUser ? 'Edit User' : 'New User' ?></h2>
+<form method="post">
+  <input type="hidden" name="csrf" value="<?=h(csrfToken())?>">
+  <?php if($editUser): ?>
+    <input type="hidden" name="id" value="<?= (int)$editUser['id'] ?>">
+  <?php endif; ?>
+  <label>Username <input name="username" value="<?=h($editUser['username'] ?? '')?>"></label><br>
+  <label>Email <input name="email" value="<?=h($editUser['email'] ?? '')?>"></label><br>
+  <label>Password <input type="password" name="password"></label><br>
+  <label>Roles
+    <select name="roles[]" multiple size="5">
+      <?php foreach($allRoles as $r): ?>
+        <option value="<?=$r['id'] ?>" <?= in_array($r['id'], $editRoles) ? 'selected' : '' ?>><?= h($r['name']) ?></option>
+      <?php endforeach; ?>
+    </select>
+  </label><br>
+  <button type="submit">Save</button>
+</form>
+
 <?php require __DIR__.'/../core/footer.php'; ?>
+


### PR DESCRIPTION
## Summary
- Implement user management with listing and role assignments
- Provide roles CRUD interface
- Add role-permission assignment screen with multi-select fields

## Testing
- `php -l app/admin/users.php`
- `php -l app/admin/roles.php`
- `php -l app/admin/role_permissions.php`


------
https://chatgpt.com/codex/tasks/task_e_68c020320cc883318b241e2477cc2800