### PR TITLE
Ensure scripts terminate after redirects

### DIFF
--- a/app/auth/logout.php
+++ b/app/auth/logout.php
@@ -1,5 +1,5 @@
-
 <?php
 require_once __DIR__.'/../core/session.php';
 session_unset(); session_destroy();
 header('Location: /app/auth/login.php');
+exit;

--- a/app/x/x_comment_add.php
+++ b/app/x/x_comment_add.php
@@ -1,4 +1,3 @@
-
 <?php
 require_once __DIR__.'/../core/bootstrap.php'; checkCsrfOrFail();
 $xId=(int)($_POST['x_id']??0); $body=trim($_POST['body']??'');
@@ -11,3 +10,4 @@ $h=$conn->prepare("INSERT INTO x_history (x_id,actor_id,action,field,new_value) 
 $a='comment_added'; $f='comment'; $h->bind_param('iisss',$xId,$userId,$a,$f,$body); $h->execute(); $h->close();
 audit($conn,$userId,'x.comment','x',(string)$xId,null);
 header("Location: x_view.php?id=".$xId."#comments");
+exit;

--- a/app/x/x_create.php
+++ b/app/x/x_create.php
@@ -1,4 +1,3 @@
-
 <?php
 require_once __DIR__.'/../core/bootstrap.php';
 requirePerm($perms,'x.create');
@@ -11,3 +10,4 @@ $h=$conn->prepare("INSERT INTO x_history (x_id,actor_id,action,field,new_value) 
 $act='created'; $fld='title'; $nv=$title; $h->bind_param('iisss',$id,$userId,$act,$fld,$nv); $h->execute(); $h->close();
 audit($conn,$userId,'x.create','x',(string)$id,['title'=>$title]);
 header("Location: x_view.php?id=".$id);
+exit;

--- a/app/x/x_delete.php
+++ b/app/x/x_delete.php
@@ -1,4 +1,3 @@
-
 <?php
 require_once __DIR__.'/../core/bootstrap.php'; checkCsrfOrFail(); requirePerm($perms,'x.delete');
 $id=(int)($_GET['id']??0); if ($id<=0){ http_response_code(400); exit('bad'); }
@@ -12,3 +11,4 @@ $h=$conn->prepare("INSERT INTO x_history (x_id,actor_id,action) VALUES (?,?, 'de
 $h->bind_param('ii',$id,$userId); $h->execute(); $h->close();
 $conn->commit(); audit($conn,$userId,'x.delete','x',(string)$id,null);
 header('Location: x_list.php');
+exit;

--- a/app/x/x_file_upload.php
+++ b/app/x/x_file_upload.php
@@ -1,4 +1,3 @@
-
 <?php
 require_once __DIR__.'/../core/bootstrap.php'; checkCsrfOrFail();
 $xId=(int)($_POST['x_id']??0);
@@ -17,3 +16,4 @@ $h=$conn->prepare("INSERT INTO x_history (x_id,actor_id,action,field,new_value) 
 $a='file_added'; $f='file'; $nv=$orig; $h->bind_param('iisss',$xId,$userId,$a,$f,$nv); $h->execute(); $h->close();
 audit($conn,$userId,'x.file.add','x',(string)$xId,['file'=>$orig]);
 header("Location: x_view.php?id=".$xId."#files");
+exit;

--- a/app/x/x_update.php
+++ b/app/x/x_update.php
@@ -1,4 +1,3 @@
-
 <?php
 require_once __DIR__.'/../core/bootstrap.php'; checkCsrfOrFail(); requirePerm($perms,'x.update');
 $id=(int)($_POST['id']??0); if ($id<=0){ http_response_code(400); exit('bad'); }
@@ -19,3 +18,4 @@ if ($desc!==$oD){ $a='updated'; $f='description'; $log->bind_param('iissss',$id,
 if ($status!==$oS){ $a='status_change'; $f='status'; $log->bind_param('iissss',$id,$userId,$a,$f,$oS,$status); $log->execute(); }
 $log->close(); audit($conn,$userId,'x.update','x',(string)$id,['title'=>$title,'status'=>$status]);
 header("Location: x_view.php?id=".$id);
+exit;


### PR DESCRIPTION
## Summary
- Add explicit `exit` calls after `header()` redirects in authentication and x-related scripts.
- Remove leading blank lines to avoid accidental output before headers.

## Testing
- `php -l app/auth/logout.php`
- `php -l app/x/x_file_upload.php`
- `php -l app/x/x_delete.php`
- `php -l app/x/x_update.php`
- `php -l app/x/x_create.php`
- `php -l app/x/x_comment_add.php`
- `php app/auth/logout.php` *(fails: Session warnings due to headers already sent)*
- `php app/x/x_file_upload.php` *(fails: mysqli_sql_exception - No such file or directory)*

------
https://chatgpt.com/codex/tasks/task_e_68c01e4f38cc8331aeaeaf19da7e7a76