### PR TITLE
Add initial user registration

### DIFF
--- a/app/auth/login.php
+++ b/app/auth/login.php
@@ -8,6 +8,11 @@ require_once __DIR__.'/../core/audit.php';
 require_once __DIR__.'/../core/rbac.php';
 require_once __DIR__.'/../core/auth.php';
 
+// redirect to registration if no user exists yet
+$cntRes=$conn->query("SELECT COUNT(*) cnt FROM user");
+$hasUser=((int)($cntRes->fetch_assoc()['cnt']??0))>0;
+if(!$hasUser){ header('Location: /app/auth/register.php'); exit; }
+
 if ($_SERVER['REQUEST_METHOD']==='POST') {
   checkCsrfOrFail();
   $u=trim($_POST['username']??''); $p=$_POST['password']??'';

--- a/app/auth/register.php
+++ b/app/auth/register.php
@@ -1,0 +1,49 @@
+<?php
+require_once __DIR__.'/../core/db.php';
+require_once __DIR__.'/../core/session.php';
+require_once __DIR__.'/../core/csrf.php';
+require_once __DIR__.'/../core/security.php';
+require_once __DIR__.'/../core/audit.php';
+
+// allow registration only if no user exists yet
+$cntRes=$conn->query("SELECT COUNT(*) cnt FROM user");
+$hasUser=((int)($cntRes->fetch_assoc()['cnt']??0))>0;
+if($hasUser){ http_response_code(403); exit('forbidden'); }
+
+if($_SERVER['REQUEST_METHOD']==='POST'){
+  checkCsrfOrFail();
+  $u=trim($_POST['username']??'');
+  $e=trim($_POST['email']??'');
+  $p=$_POST['password']??'';
+  if($u===''||$e===''||$p===''){ http_response_code(422); exit('missing'); }
+  $hash=password_hash($p,PASSWORD_DEFAULT);
+  $conn->begin_transaction();
+  try{
+    $st=$conn->prepare("INSERT INTO user (username,email,password_hash,email_verified_at) VALUES (?,?,?,UTC_TIMESTAMP())");
+    $st->bind_param('sss',$u,$e,$hash);
+    $st->execute();
+    $uid=$st->insert_id; $st->close();
+    $role=1;
+    $st=$conn->prepare("INSERT INTO user_role (user_id,role_id) VALUES (?,?)");
+    $st->bind_param('ii',$uid,$role);
+    $st->execute(); $st->close();
+    $conn->commit();
+    audit($conn,$uid,'user.register','user',(string)$uid,null);
+  }catch(Throwable $ex){
+    $conn->rollback();
+    http_response_code(500); exit('error');
+  }
+  session_regenerate_id(true);
+  $_SESSION['user_id']=(int)$uid;
+  header('Location: /app/x/x_list.php'); exit;
+}
+?>
+<?php $title='Register'; require __DIR__.'/../core/header.php'; ?>
+<form method="post">
+  <input type="hidden" name="csrf" value="<?=htmlspecialchars(csrfToken(),ENT_QUOTES)?>">
+  <label>Username <input name="username" required></label><br>
+  <label>Email <input type="email" name="email" required></label><br>
+  <label>Password <input type="password" name="password" required></label><br>
+  <button type="submit">Register</button>
+</form>
+<?php require __DIR__.'/../core/footer.php'; ?>


### PR DESCRIPTION
## Summary
- Redirect login page to registration when user table is empty
- Introduce registration page to create first account and assign SuperAdmin role

## Testing
- `php -l app/auth/register.php`
- `php -l app/auth/login.php`


------
https://chatgpt.com/codex/tasks/task_e_68c025706fe08331b16b9bf28a74a517