### PR TITLE
Fix base URL for links and redirects

### DIFF
--- a/app/auth/login.php
+++ b/app/auth/login.php
@@ -11,7 +11,7 @@ require_once __DIR__.'/../core/auth.php';
 // redirect to registration if no user exists yet
 $cntRes=$conn->query("SELECT COUNT(*) cnt FROM user");
 $hasUser=((int)($cntRes->fetch_assoc()['cnt']??0))>0;
-if(!$hasUser){ header('Location: /app/auth/register.php'); exit; }
+  if(!$hasUser){ header('Location: '.BASE_URL.'/app/auth/register.php'); exit; }
 
 if ($_SERVER['REQUEST_METHOD']==='POST') {
   checkCsrfOrFail();
@@ -25,7 +25,7 @@ if ($_SERVER['REQUEST_METHOD']==='POST') {
   session_regenerate_id(true);
   $_SESSION['user_id']=(int)$user['id'];
   audit($conn,$user['id'],'login.success','user',(string)$user['id'],null);
-  header('Location: /app/x/x_list.php'); exit;
+    header('Location: '.BASE_URL.'/app/x/x_list.php'); exit;
 }
 ?>
 <?php $title='Login'; require __DIR__.'/../core/header.php'; ?>

--- a/app/auth/logout.php
+++ b/app/auth/logout.php
@@ -1,5 +1,5 @@
 <?php
 require_once __DIR__.'/../core/session.php';
 session_unset(); session_destroy();
-header('Location: /app/auth/login.php');
+header('Location: '.BASE_URL.'/app/auth/login.php');
 exit;

--- a/app/auth/register.php
+++ b/app/auth/register.php
@@ -35,7 +35,7 @@ if($_SERVER['REQUEST_METHOD']==='POST'){
   }
   session_regenerate_id(true);
   $_SESSION['user_id']=(int)$uid;
-  header('Location: /app/x/x_list.php'); exit;
+    header('Location: '.BASE_URL.'/app/x/x_list.php'); exit;
 }
 ?>
 <?php $title='Register'; require __DIR__.'/../core/header.php'; ?>

--- a/app/core/config.php
+++ b/app/core/config.php
@@ -1,0 +1,5 @@
+<?php
+// Base URL for all application links
+// Adjust this if the project directory changes
+const BASE_URL = '/2xtreme';
+

--- a/app/core/db.php
+++ b/app/core/db.php
@@ -1,5 +1,7 @@
 
 <?php
+require_once __DIR__.'/config.php';
+
 $DB_HOST = 'localhost';
 $DB_USER = 'root';
 $DB_PASS = '';

--- a/app/core/header.php
+++ b/app/core/header.php
@@ -5,20 +5,20 @@
 <meta charset="utf-8">
 <title><?=htmlspecialchars($title ?? '2xtreme', ENT_QUOTES)?></title>
 <link href="https://cdn.jsdelivr.net/npm/bootstrap@5.3.2/dist/css/bootstrap.min.css" rel="stylesheet">
-<link rel="stylesheet" href="/app/public/css/style.css">
+<link rel="stylesheet" href="<?=BASE_URL?>/app/public/css/style.css">
 </head>
 <body class="bg-light">
 <nav class="navbar navbar-expand-lg navbar-light bg-white shadow-sm">
   <div class="container">
-    <a class="navbar-brand" href="/index.php">2xtreme</a>
+    <a class="navbar-brand" href="<?=BASE_URL?>/index.php">2xtreme</a>
     <button class="navbar-toggler" type="button" data-bs-toggle="collapse" data-bs-target="#mainNav" aria-controls="mainNav" aria-expanded="false" aria-label="Toggle navigation">
       <span class="navbar-toggler-icon"></span>
     </button>
     <div class="collapse navbar-collapse" id="mainNav">
       <ul class="navbar-nav ms-auto mb-2 mb-lg-0">
-        <li class="nav-item"><a class="nav-link" href="/app/x/x_list.php">X</a></li>
-        <li class="nav-item"><a class="nav-link" href="/app/admin/users.php">Users</a></li>
-        <li class="nav-item"><a class="nav-link" href="/app/auth/logout.php">Logout</a></li>
+        <li class="nav-item"><a class="nav-link" href="<?=BASE_URL?>/app/x/x_list.php">X</a></li>
+        <li class="nav-item"><a class="nav-link" href="<?=BASE_URL?>/app/admin/users.php">Users</a></li>
+        <li class="nav-item"><a class="nav-link" href="<?=BASE_URL?>/app/auth/logout.php">Logout</a></li>
       </ul>
     </div>
   </div>

--- a/app/core/rbac.php
+++ b/app/core/rbac.php
@@ -1,7 +1,7 @@
 
 <?php
 function requireLogin(): void {
-  if (!isset($_SESSION['user_id'])) { header('Location: /app/auth/login.php'); exit; }
+  if (!isset($_SESSION['user_id'])) { header('Location: '.BASE_URL.'/app/auth/login.php'); exit; }
 }
 function userPermissions(mysqli $c, int $userId): array {
   $sql = "SELECT p.code FROM user_role ur

--- a/app/core/session.php
+++ b/app/core/session.php
@@ -1,5 +1,7 @@
 
 <?php
+require_once __DIR__.'/config.php';
+
 session_name('user_session');
 session_start([
   'cookie_secure'   => false,


### PR DESCRIPTION
## Summary
- Add `BASE_URL` config constant to represent `/2xtreme`
- Load config in core modules and update header/navigation paths
- Use `BASE_URL` in auth and RBAC redirects

## Testing
- `php -l app/core/config.php app/core/db.php app/core/session.php app/core/header.php app/core/rbac.php app/auth/login.php app/auth/register.php app/auth/logout.php`


------
https://chatgpt.com/codex/tasks/task_e_68c027a429cc833188c4d6dae22ad4e7