### PR TITLE
Allow multiple users and reset login attempts

### DIFF
--- a/app/auth/login.php
+++ b/app/auth/login.php
@@ -22,6 +22,7 @@ if ($_SERVER['REQUEST_METHOD']==='POST') {
   $ok=$user && $user['is_active'] && $user['email_verified_at']!==null && verifyPassword($user['password_hash'],$p);
   recordAttempt($conn,$u,$ok);
   if (!$ok){ audit($conn,null,'login.fail','user',$u,null); http_response_code(401); exit('invalid'); }
+  clearLoginAttempts($conn,$u);
   session_regenerate_id(true);
   $_SESSION['user_id']=(int)$user['id'];
   audit($conn,$user['id'],'login.success','user',(string)$user['id'],null);

--- a/app/auth/register.php
+++ b/app/auth/register.php
@@ -4,11 +4,7 @@ require_once __DIR__.'/../core/session.php';
 require_once __DIR__.'/../core/csrf.php';
 require_once __DIR__.'/../core/security.php';
 require_once __DIR__.'/../core/audit.php';
-
-// allow registration only if no user exists yet
-$cntRes=$conn->query("SELECT COUNT(*) cnt FROM user");
-$hasUser=((int)($cntRes->fetch_assoc()['cnt']??0))>0;
-if($hasUser){ http_response_code(403); exit('forbidden'); }
+require_once __DIR__.'/../core/auth.php';
 
 if($_SERVER['REQUEST_METHOD']==='POST'){
   checkCsrfOrFail();
@@ -27,6 +23,7 @@ if($_SERVER['REQUEST_METHOD']==='POST'){
     $st=$conn->prepare("INSERT INTO user_role (user_id,role_id) VALUES (?,?)");
     $st->bind_param('ii',$uid,$role);
     $st->execute(); $st->close();
+    clearLoginAttempts($conn,$u);
     $conn->commit();
     audit($conn,$uid,'user.register','user',(string)$uid,null);
   }catch(Throwable $ex){

--- a/app/core/auth.php
+++ b/app/core/auth.php
@@ -16,3 +16,7 @@ function tooManyFails(mysqli $c, string $u, int $n=5, int $min=15): bool {
   $st=$c->prepare("SELECT COUNT(*) cnt FROM login_attempt WHERE username=? AND succeeded=0 AND created_at>DATE_SUB(UTC_TIMESTAMP(), INTERVAL ? MINUTE)");
   $st->bind_param('si',$u,$min); $st->execute(); $cnt=$st->get_result()->fetch_assoc()['cnt']??0; return $cnt>=$n;
 }
+function clearLoginAttempts(mysqli $c, string $u): void {
+  $st=$c->prepare("DELETE FROM login_attempt WHERE username=?");
+  $st->bind_param('s',$u); $st->execute(); $st->close();
+}


### PR DESCRIPTION
## Summary
- remove single-user limit for registration
- reset login attempts after successful login or registration

## Testing
- `php -l app/auth/register.php`
- `php -l app/core/auth.php`
- `php -l app/auth/login.php`


------
https://chatgpt.com/codex/tasks/task_e_68c02a3910048331b4c94ff93ea80d1e